### PR TITLE
feat: Timeline activité enrichie (#23)

### DIFF
--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -457,9 +457,14 @@ function RecentActivity() {
                   <div className="pb-4 pt-0.5 flex-1 min-w-0">
                     <div className="flex items-center justify-between gap-2">
                       <p className="text-sm">
-                        <span className="font-mono text-xs text-muted-foreground">{activity.quoteNumber}</span>
+                        <Link href={`/quotes/${activity.quoteId}`} className="font-mono text-xs text-indigo-600 hover:underline">
+                          {activity.quoteNumber}
+                        </Link>
                         {" — "}
                         <span className="text-muted-foreground">{description}</span>
+                        {activity.clientName && (
+                          <span className="text-muted-foreground"> · {activity.clientName}</span>
+                        )}
                       </p>
                       <span className="text-xs text-muted-foreground whitespace-nowrap">
                         {formatTimeAgo(activity.createdAt)}

--- a/src/app/(dashboard)/quotes/page.tsx
+++ b/src/app/(dashboard)/quotes/page.tsx
@@ -154,6 +154,14 @@ export default function QuotesPage() {
               const status = statusConfig[item.quote.status] ?? statusConfig.draft;
               return <Badge variant={status.variant}>{status.label}</Badge>;
             }},
+            { key: "views", header: "Vues", render: (item) => {
+              const count = item.quote.viewCount ?? 0;
+              return count > 0 ? (
+                <span className="flex items-center gap-1 text-sm text-muted-foreground">
+                  <Eye className="h-3 w-3" /> {count}
+                </span>
+              ) : <span className="text-sm text-muted-foreground">—</span>;
+            }},
             { key: "total", header: "Total TTC", className: "text-right", render: (item) => <span className="font-medium">{formatCurrency(item.quote.total)} €</span> },
             { key: "date", header: "Date", className: "text-muted-foreground text-sm", render: (item) => formatDate(item.quote.createdAt) },
           ]}

--- a/src/server/api/routers/notifications.ts
+++ b/src/server/api/routers/notifications.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { router, protectedProcedure } from "../trpc";
-import { quotes, invoices, quoteActivities } from "@/db/schema";
+import { quotes, invoices, quoteActivities, clients } from "@/db/schema";
 import { eq, and, desc, inArray, sql, gte } from "drizzle-orm";
 
 export const notificationsRouter = router({
@@ -92,22 +92,35 @@ export const notificationsRouter = router({
             if (activity.metadata) meta = JSON.parse(activity.metadata);
           } catch {}
 
+          let clientName: string | undefined;
+
           // Try to get quote number from metadata first
           let quoteNumber = meta.quoteNumber as string | undefined;
 
           // If not in metadata, look it up
           if (!quoteNumber && activity.quoteId) {
             const [q] = await ctx.db
-              .select({ quoteNumber: quotes.quoteNumber, title: quotes.title })
+              .select({ quoteNumber: quotes.quoteNumber, title: quotes.title, clientId: quotes.clientId })
               .from(quotes)
               .where(eq(quotes.id, activity.quoteId))
               .limit(1);
             quoteNumber = q?.quoteNumber;
+
+            // Get client name
+            if (q?.clientId) {
+              const [c] = await ctx.db
+                .select({ name: clients.name })
+                .from(clients)
+                .where(eq(clients.id, q.clientId))
+                .limit(1);
+              clientName = c?.name ?? undefined;
+            }
           }
 
           return {
             ...activity,
             quoteNumber: quoteNumber ?? "—",
+            clientName,
             metadata: meta,
           };
         })

--- a/src/server/api/routers/quotes.ts
+++ b/src/server/api/routers/quotes.ts
@@ -239,6 +239,27 @@ export const quotesRouter = router({
       return activities;
     }),
 
+  // ── Get recent activity (global feed) ─────────────
+  getRecentActivity: protectedProcedure
+    .input(z.object({ limit: z.number().min(1).max(50).optional().default(20) }))
+    .query(async ({ ctx, input }) => {
+      const activities = await ctx.db
+        .select({
+          activity: quoteActivities,
+          quoteNumber: quotes.quoteNumber,
+          quoteTitle: quotes.title,
+          clientName: clients.name,
+        })
+        .from(quoteActivities)
+        .innerJoin(quotes, eq(quoteActivities.quoteId, quotes.id))
+        .leftJoin(clients, eq(quotes.clientId, clients.id))
+        .where(eq(quotes.organizationId, ctx.organizationId!))
+        .orderBy(desc(quoteActivities.createdAt))
+        .limit(input.limit);
+
+      return activities;
+    }),
+
   // ── Create quote ──────────────────────────────────
   create: protectedProcedure
     .input(createQuoteInput)


### PR DESCRIPTION
Fixes #23

- Lien cliquable sur chaque activité → page devis
- Affichage nom client dans le feed global
- Colonne 'Vues' (icôle Eye + count) sur la liste des devis
- Endpoint getRecentActivity enrichi avec clientName
- Base existante conservée : Timeline par devis, icons, formatTimeAgo